### PR TITLE
Inlined.batch import

### DIFF
--- a/cloud/consts.js
+++ b/cloud/consts.js
@@ -54,7 +54,17 @@ module.exports = {
   // See FINISHED_SECOND_PASS for full documentation.
   NEEDS_SECOND_PASS: 3,
 
+  // Another hack around the state machine:
+  // when we run our initial import, we need to set various fields (e.g.
+  // that the object is migrated) but we might also want to set various
+  // fields about the Firebase copy of the data. The first write after this
+  // state skips a logical beforeSave trigger to avoid weird side effects.
+  JUST_IMPORTED: 4,
+
   // The number of records that are queried at once in the migration job.
   // This is exported so it can be lowered in tests.
-  BATCH_SIZE: 1000
+  IMPORT_BATCH_SIZE: 1000,
+
+  // The number of records you can send to a bulk save request in Parse.
+  SAVE_BATCH_SIZE: 50
 };

--- a/cloud/consts.js
+++ b/cloud/consts.js
@@ -59,7 +59,7 @@ module.exports = {
   // that the object is migrated) but we might also want to set various
   // fields about the Firebase copy of the data. The first write after this
   // state skips a logical beforeSave trigger to avoid weird side effects.
-  JUST_IMPORTED: 4,
+  IMPORTED: 4,
 
   // The number of records that are queried at once in the migration job.
   // This is exported so it can be lowered in tests.

--- a/cloud/migrator.js
+++ b/cloud/migrator.js
@@ -229,7 +229,7 @@ Migrator.prototype.getAfterDelete = function(klass) {
 // importer or the migration function. Any changes made by the import function
 // plus a change to the object's migration state are applied to the objects,
 // which are saved back in bulk.
-// Returns the number of objects imported.
+// The function it creates returns the number of objects imported.
 Migrator.prototype.getBulkImport = function(klass) {
   var migrate = this.handlers(klass).migrateObject,
     bulkImport = this.handlers(klass).bulkImport,
@@ -259,7 +259,7 @@ Migrator.prototype.getBulkImport = function(klass) {
       });
     } else {
       migrations = bulkImport(objects).then(function(changed) {
-        return _.map(changed, function(object) {
+        return _.each(changed, function(object) {
           object.set(consts.MIGRATION_KEY, consts.IMPORTED);
         });
       });
@@ -270,12 +270,7 @@ Migrator.prototype.getBulkImport = function(klass) {
       for (var start = 0; start < objects.length; start += consts.SAVE_BATCH_SIZE) {
         var slice = objects.slice(start, start + consts.SAVE_BATCH_SIZE);
         saveBack = saveBack.then(function() {
-          var p = new _Promise();
-          _Parse.Object.saveAll(slice, {
-            success: function() { p.resolve() },
-            error: function(err) { p.reject(err) }
-          });
-          return p;
+          return _Parse.Object.saveAll(slice);
         });
       }
       return saveBack.then(function() {

--- a/cloud/migrator.js
+++ b/cloud/migrator.js
@@ -65,6 +65,7 @@ var Migrator = function(Parse) {
   // create jobs/functions.
   this.migrateObject = this._registerFn("migrateObject");
   this.migrateDelete = this._registerFn("migrateDelete");
+  this.bulkImport = this._registerFn("bulkImport");
 
   this._parse = Parse;
 };
@@ -121,11 +122,16 @@ Migrator.prototype.getBeforeSave = function(klass) {
 
   return function(request, response) {
     var obj;
-    // Skip beforeSave if it doesn't exist or if this is just
-    // a quick second pass to keep people from worrying about not having
-    // an objectId in their migration. See consts.js for a full explanation
-    // of the state machine.
+    // Reasons to skip the logical beforeSave:
+    // * it isn't defined (only migration is)
+    // * we are skipping it because we needed a 2-pass migration for a new object
+    // * we are skipping everything because we made changes for the import job
+    // See consts.js for a full explanation of the state machine.
     var changed = request.object.dirtyKeys();
+    if (request.object.dirty(consts.MIGRATION_KEY) &&
+        request.object.get(consts.MIGRATION_KEY) === consts.JUST_IMPORTED) {
+        return;
+    }
     var shouldBeforeSave = !_.isUndefined(beforeSave) &&
       !(changed.length === 1 && changed[0] === consts.MIGRATION_KEY);
 
@@ -156,10 +162,8 @@ Migrator.prototype.getBeforeSave = function(klass) {
       }
       return _Promise.as().then(function() {
         return migrate && migrate(obj);
-      }).then(function() {
-        // migration functions shouldn't change the object or it will
-        // behave weirdly between beforeSave and the migration job.
-        return obj;
+      }).then(function(maybeNew) {
+        return maybeNew instanceof _Parse.Object ? maybeNew : obj;
       });
 
     }).then(function() {
@@ -221,6 +225,67 @@ Migrator.prototype.getAfterDelete = function(klass) {
   }
 };
 
+// Get bulk import returns a function that runs either the user's explicit
+// importer or the migration function. Any changes made by the import function
+// plus a change to the object's migration state are applied to the objects,
+// which are saved back in bulk.
+// Returns the number of objects imported.
+Migrator.prototype.getBulkImport = function(klass) {
+  var migrate = this.handlers(klass).migrateObject,
+    bulkImport = this.handlers(klass).bulkImport,
+      _Promise = this._parse.Promise;
+      _Parse = this._parse;
+
+  if (_.isUndefined(migrate) && _.isUndefined(bulkImport)) {
+    return undefined;
+  }
+
+  return function(objects) {
+    var migrations;
+    if (_.isUndefined(bulkImport)) {
+      // If the user has not defined a bulkImport method, we first let them run their
+      // migration methods in parallel. After they all complete, we batch the saves
+      // in a Parse.Object.saveAll request. We sequence these methods because saveAll
+      // counts in Parse as N requests and a parallel save is likely to make customers
+      // hit their throughput limit.
+      migrations = _.map(objects, function(object) {
+        return _Promise.as().then(function() {
+          return migrate(object);
+        }).then(function(maybeChanged) {
+          var ret = maybeChanged instanceof _Parse.Object ? maybeChanged : object;
+          ret.set(consts.MIGRATION_KEY, consts.JUST_IMPORTED);
+          return ret;
+        });
+      });
+    } else {
+      migrations = bulkImport(objects).then(function(changed) {
+        return _.map(changed, function(object) {
+          object.set(consts.MIGRATION_KEY, consts.JUST_IMPORTED);
+        });
+      });
+    }
+
+    return _Promise.when(migrations).then(function(objects) {
+      var saveBack = _Promise.as();
+      for (var start = 0; start < objects.length; start += consts.SAVE_BATCH_SIZE) {
+        var slice = objects.slice(start, start + consts.SAVE_BATCH_SIZE);
+        saveBack = saveBack.then(function() {
+          var p = new _Promise();
+          _Parse.Object.saveAll(slice, {
+            success: function() { p.resolve() },
+            error: function(err) { p.reject(err) }
+          });
+          return p;
+        });
+      }
+      return saveBack.then(function() {
+        return objects.length;
+      });
+    });
+  }
+};
+
+
 Migrator.prototype.getImportJob = function() {
   var self = this,
     _Promise = this._parse.Promise;
@@ -231,8 +296,9 @@ Migrator.prototype.getImportJob = function() {
     console.log("Starting import pass");
     var totalMigrated = 0;
     _.each(self._triggers, function(handlers, klass) {
-      if (_.isUndefined(handlers.migrateObject)) {
-        console.log(klass + " has no migration function; nothing to import");
+      var importer = self.getBulkImport(klass);
+      if (_.isUndefined(importer)) {
+        console.log(klass + " has no migration or bulkImport function; nothing to import");
         return;
       } else {
         console.log("Will import class " +  klass);
@@ -241,7 +307,7 @@ Migrator.prototype.getImportJob = function() {
       lastMigration = lastMigration.then(function(migrated) {
         totalMigrated += migrated;
         console.log("Starting import of class " + klass);
-        return self._migrateClass(klass, handlers.migrateObject);
+        return self._migrateClass(klass, importer);
       });
     });
     return lastMigration.then(function(migrated) {
@@ -260,7 +326,7 @@ Migrator.prototype.getImportJob = function() {
   }
 };
 
-Migrator.prototype._migrateClass = function(klass, migration, deadline) {
+Migrator.prototype._migrateClass = function(klass, bulkImport, deadline) {
   var self = this,
     _Promise = this._parse.Promise;
   if (Date.now() > deadline) {
@@ -278,27 +344,19 @@ Migrator.prototype._migrateClass = function(klass, migration, deadline) {
   var query = new self._parse.Query(klass)
     .notContainedIn(
       consts.MIGRATION_KEY,
-      [consts.IS_MIGRATED, consts.NEEDS_SECOND_PASS, consts.FINISHED_SECOND_PASS]
+      [
+        consts.IS_MIGRATED,
+        consts.NEEDS_SECOND_PASS,
+        consts.FINISHED_SECOND_PASS,
+        consts.JUST_IMPORTED
+      ]
     ).limit(consts.BATCH_SIZE);
 
   // For each batch, map that batch to a migration of a single record and
   // then setting that record's migration status to done. Then wait for
   // that batch to complete before resolving the outer promise that lets
   // us fetch a new batch.
-  return query.find().then(function(objects) {
-    var migrations = _.map(objects, function(object) {
-      return _Promise.as().then(function() {
-        return migration(object);
-      }).then(function() {
-        object.set(consts.MIGRATION_KEY, consts.IS_MIGRATED);
-        return object.save();
-      });
-    });
-    return _Promise.when(migrations).then(function() {
-      return migrations.length;
-    });
-
-  }).then(function(migrated) {
+  return query.find().then(bulkImport).then(function(migrated) {
     // We know we've migrated everything when the last batch didn't hit our limit.
     // Otherwise, recursion is the for loop of async.
     if (migrated === consts.BATCH_SIZE) {

--- a/cloud/migrator.js
+++ b/cloud/migrator.js
@@ -129,8 +129,8 @@ Migrator.prototype.getBeforeSave = function(klass) {
     // See consts.js for a full explanation of the state machine.
     var changed = request.object.dirtyKeys();
     if (request.object.dirty(consts.MIGRATION_KEY) &&
-        request.object.get(consts.MIGRATION_KEY) === consts.JUST_IMPORTED) {
-        return;
+        request.object.get(consts.MIGRATION_KEY) === consts.IMPORTED) {
+        return _Promise.as();
     }
     var shouldBeforeSave = !_.isUndefined(beforeSave) &&
       !(changed.length === 1 && changed[0] === consts.MIGRATION_KEY);
@@ -253,14 +253,14 @@ Migrator.prototype.getBulkImport = function(klass) {
           return migrate(object);
         }).then(function(maybeChanged) {
           var ret = maybeChanged instanceof _Parse.Object ? maybeChanged : object;
-          ret.set(consts.MIGRATION_KEY, consts.JUST_IMPORTED);
+          ret.set(consts.MIGRATION_KEY, consts.IMPORTED);
           return ret;
         });
       });
     } else {
       migrations = bulkImport(objects).then(function(changed) {
         return _.map(changed, function(object) {
-          object.set(consts.MIGRATION_KEY, consts.JUST_IMPORTED);
+          object.set(consts.MIGRATION_KEY, consts.IMPORTED);
         });
       });
     }
@@ -348,7 +348,7 @@ Migrator.prototype._migrateClass = function(klass, bulkImport, deadline) {
         consts.IS_MIGRATED,
         consts.NEEDS_SECOND_PASS,
         consts.FINISHED_SECOND_PASS,
-        consts.JUST_IMPORTED
+        consts.IMPORTED
       ]
     ).limit(consts.BATCH_SIZE);
 

--- a/cloud/test.js
+++ b/cloud/test.js
@@ -615,7 +615,7 @@ describe('migrator', function() {
         return Parse.Promise.when(fetchMigrated);
       }).then(function(objects) {
         _.each(objects, function(obj) {
-          assert.equal(obj.get(consts.MIGRATION_KEY), consts.IS_MIGRATED);
+          assert.equal(obj.get(consts.MIGRATION_KEY), consts.JUST_IMPORTED);
         });
       });
     });

--- a/cloud/test.js
+++ b/cloud/test.js
@@ -170,6 +170,15 @@ describe('migrator', function() {
   newObject.set('foo', 'bar');
   var newObjectRequest = {object: newObject};
 
+  var importedObject = Parse.Object.fromJSON({
+    className: 'Class',
+    objectId: 'imported',
+    original: 'field'
+  });
+  importedObject.set('firebaseRel', 'somethingFromImport');
+  importedObject.set(consts.MIGRATION_KEY, consts.IMPORTED);
+  var importedObjectRequest = {object: importedObject};
+
   // Create an object that keeps control flow for before/after
   // save triggers in promisy mode.
   var response = {
@@ -199,7 +208,8 @@ describe('migrator', function() {
       var allTriggers = [
         'beforeSave', 'afterSave',
         'beforeDelete', 'afterDelete',
-        'migrateObject', 'migrateDelete'
+        'migrateObject', 'migrateDelete',
+        'bulkImport'
       ];
       var noop = function() {};
 
@@ -321,9 +331,22 @@ describe('migrator', function() {
       migrator.migrateObject(Parse.User, ranMigration);
 
       // Generate & call the exported Parse beforeSave trigger.
-      var exportedTrigger = migrator.getBeforeSave(Parse.User)
+      var exportedTrigger = migrator.getBeforeSave(Parse.User);
       return exportedTrigger(newObjectRequest, response).then(function() {
         ranBeforeSave.assertTrue();
+        ranMigration.assertFalse();
+      });
+    });
+
+    it('should not run migrations or beforeSave for objects on on import', function() {
+      var ranBeforeSave = latch();
+      var ranMigration = latch();
+      migrator.beforeSave(Parse.User, ranBeforeSave);
+      migrator.migrateObject(Parse.User, ranMigration);
+
+      var exportedTrigger = migrator.getBeforeSave(Parse.User);
+      return exportedTrigger(importedObjectRequest, response).then(function() {
+        ranBeforeSave.assertFalse();
         ranMigration.assertFalse();
       });
     });
@@ -555,68 +578,164 @@ describe('migrator', function() {
     });
   });
 
-  describe('migration job', function() {
-    it('should handle a smoke test (live traffic)', function() {
-      // This involves a lot of network requests; give it a minute
+  describe('migration job (smoke test)', function() {
+    var saveBatchSize, importBatchSize, testCases;
+    var classNames = [];
+    var numClassNames = 2;
+    before(function() {
       this.timeout(60 * 1000);
-      consts.BATCH_SIZE = 2;
-      var classNameA = 'MigrationJobTest_' + randomString(10);
-      var classNameB = 'MigrationJobTest_' + randomString(10);
+
+      saveBatchSize = consts.SAVE_BATCH_SIZE;
+      importBatchSize = consts.IMPORT_BATCH_SIZE;
+      saveBatchSize = 2;
+      importBatchSize = 3;
+      testCases = 7;
+      classNames = [];
+    });
+    after(function() {
+      consts.SAVE_BATCH_SIZE = saveBatchSize;
+      consts.IMPORT_BATCH_SIZE = importBatchSize;
+    });
+
+    runTest = function(config) {
+      // This involves a lot of network requests; give it a minute
+      for (var i = 0; i < numClassNames; i++) {
+        classNames.push('MigrationJobTest_' + randomString(10));
+      }
+
       var objects = [];
 
       // Should not call before/AfterSave if we're only changing the migraiton
       // status
       var calledBeforeSave = latch();
       var calledAfterSave = latch();
-      var migratedLatch = {};
-      var migratedObjectIds = {};
-      _.each([classNameA, classNameB], function(klass) {
-        objects.push(new Parse.Object(klass, {
-          condition: 'not_migrated',
-        }));
+      _.each(classNames, function(klass) {
+        for (var testCase = 0; testCase < testCases; testCase++) {
+          objects.push(new Parse.Object(klass, {
+            condition: 'not_migrated',
+            testCase: testCase
+          }));
+        }
+
         objects.push(new Parse.Object(klass, {
           condition: 'already_migrated',
-          migrationStatus: 1,
+          migrationStatus: consts.IS_MIGRATED,
         }));
         objects.push(new Parse.Object(klass, {
           condition: 'finished_second_pass',
-          migrationStatus: 2,
+          migrationStatus: consts.FINISHED_SECOND_PASS,
         }));
         objects.push(new Parse.Object(klass, {
           condition: 'needs_second_pass',
-          migrationStatus: 3,
+          migrationStatus: consts.NEEDS_SECOND_PASS,
+        }));
+        objects.push(new Parse.Object(klass, {
+          condition: 'already_imported',
+          migrationStatus: consts.IMPORTED,
         }));
 
-        migratedLatch[klass] = latch();
         migrator.beforeSave(klass, calledBeforeSave);
         migrator.afterSave(klass, calledAfterSave);
-        migrator.migrateObject(klass, function(obj) {
-          migratedLatch[klass].assertFalse(); // only migrate once
-          migratedLatch[klass]();
-          assert.equal(obj.get('condition'), 'not_migrated');
-          migratedObjectIds[klass] = obj.id;
-        });
       });
 
       return Parse.Object.saveAll(objects).then(function() {
         return migrator.getImportJob()(undefined, response);
       }).then(function(migrated) {
-        assert.equal(migrated, 2);
+        assert.equal(migrated, numClassNames * testCases);
         calledBeforeSave.assertFalse();
         calledAfterSave.assertFalse();
-        migratedLatch[classNameA].assertTrue();
-        migratedLatch[classNameB].assertTrue();
 
-        var fetchMigrated = _.map(migratedObjectIds, function(id, klass) {
-          var obj = new Parse.Object(klass)
-          obj.id = id;
-          return obj.fetch();
-        });
-        return Parse.Promise.when(fetchMigrated);
-      }).then(function(objects) {
-        _.each(objects, function(obj) {
-          assert.equal(obj.get(consts.MIGRATION_KEY), consts.JUST_IMPORTED);
-        });
+        return config.check();
+      });
+    };
+
+    it('should handle batchImport', function() {
+      var migratedLatch = {};
+      var importedLatch = {};
+      var importedObjectIds = {};
+
+      runTest({
+        setup: function(migrator) {
+          _.each(numClassNames, function(klass) {
+            migratedLatch[klass] = latch();
+            importedLatch[klass] = latch();
+
+            migrator.migrateObject(klass, migratedLatch[klass]);
+            migrator.bulkImport(klass, function(objects) {
+              _.each(objects, function(object) {
+                if (obj.get('testCase') === 0) {
+                  migratedLatch[klass].assertFalse(); // only migrate once
+                  migratedLatch[klass]();
+                }
+                assert.equal(obj.get('condition'), 'not_migrated');
+                ids = migratedObjectIds[klass] || [];
+                ids.push(obj.id);
+                migratedObjectIds[klass] = ids;
+              });
+              return objects;
+            });
+          });
+        },
+        check: function() {
+          migratedLatch[classNameA].assertTrue();
+          migratedLatch[classNameB].assertTrue();
+          var fetchMigrated = _.map(migratedObjectIds, function(ids, klass) {
+            var objs = _.map(ids, function(id) {
+              var obj = new Parse.Object(klass)
+              obj.id = id;
+            });
+            return Parse.Object.fetchAll(objs);
+          });
+          return Parse.Promise.when(fetchMigrated).then(function(migrated) {
+            return _.flatten(migrated);
+          }).then(function(objects) {
+            _.each(objects, function(obj) {
+              assert.equal(obj.get(consts.MIGRATION_KEY), consts.IMPORTED);
+            });
+          });
+        }
+      });
+    });
+
+    it('should be able to import with migrateObject', function() {
+      var migratedLatch = {};
+      var migratedObjectIds = {};
+
+      runTest({
+        setup: function(migrator) {
+          _.each(numClassNames, function(klass) {
+            migratedLatch[klass] = latch();
+
+            migrator.migrateObject(klass, function(obj) {
+              if (obj.get('testCase') === 0) {
+                migratedLatch[klass].assertFalse(); // only migrate once
+                migratedLatch[klass]();
+              }
+              assert.equal(obj.get('condition'), 'not_migrated');
+              ids = migratedObjectIds[klass] || [];
+              ids.push(obj.id);
+              migratedObjectIds[klass] = ids;
+            });
+          });
+        },
+        check: function() {
+          migratedLatch[classNameA].assertTrue();
+          migratedLatch[classNameB].assertTrue();
+          var fetchMigrated = _.map(migratedObjectIds, function(ids, klass) {
+            var objs = _.map(ids, function(id) {
+              var obj = new Parse.Object(klass)
+              obj.id = id;
+            });
+            return Parse.Object.fetchAll(objs);
+          });
+          return Parse.Promise.when(fetchMigrated).then(function(migrated) {
+            return _.flatten(migrated);
+          }).then(function(objects) {
+            _.each(objects, function(obj) {
+              assert.equal(obj.get(consts.MIGRATION_KEY), consts.IMPORTED);
+            });
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
This will help devs write more efficient initial imports. It will also let me add a more efficient implementation for push import since both APNs tokens and subscription APIs have a batch method.

In preparation for the push migration tools I also let migration code return a modified object to be saved back. To prevent this from immediately triggering the beforeSave or migration callbacks I had to add yet another status code =/
